### PR TITLE
fix logger.With() behavior

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -104,8 +104,9 @@ func New(
 }
 
 func (l *Logger) With(args ...interface{}) Interface {
-	l.zap.With(args)
-	return l
+	clone := *l
+	clone.zap = clone.zap.With(args...)
+	return &clone
 }
 
 // Debug uses fmt.Sprint to construct and log a message.
@@ -123,7 +124,7 @@ func (l *Logger) Warn(args ...interface{}) {
 	l.zap.Warn(args...)
 }
 
-// Error uses fmt.Sprint to construct and log a mess	age.
+// Error uses fmt.Sprint to construct and log a message.
 func (l *Logger) Error(args ...interface{}) {
 	l.zap.Error(args...)
 }


### PR DESCRIPTION
This Pull Request addresses the issue where logger.With() calls were not reflected in the log output. Specifically, fields added using With() were not being included in the log entries.

Before:
Using log.With("answer", 42).Info("oops") produced:
```
{
    "level": "info",
    "ts": "2023-08-30 20:42:59.890757",
    "caller": "doctor/main.go:30",
    "msg": "oops"
}
```

After:
With the changes in this PR, using log.With("answer", 42).Info("oops") will now produce:
```
{
    "level": "info",
    "ts": "2023-08-30 20:42:59.890757",
    "caller": "doctor/main.go:30",
    "msg": "oops",
    "answer": 42
}
```