### PR TITLE
Skip Wrapper Function in Zap Caller

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -99,6 +99,8 @@ func New(
 		panic(err)
 	}
 
+	core = core.WithOptions(zap.AddCallerSkip(1))
+
 	logger = &Logger{core.Sugar()}
 	return
 }


### PR DESCRIPTION
This pull request adds the zap.AddCallerSkip(1) option to the Zap Core logger. The purpose of this change is to skip the first caller in the stack trace when using a wrapper function around Zap. This ensures that the logs display the correct caller information.

Before:
```
{"caller":"logger/logger.go:147", ... }
```

After:
```
{"caller":"usecases/deposit.go:73", ...}
```
